### PR TITLE
[FIX] Missspelling of company name (coingate) in route for callback

### DIFF
--- a/etc/frontend/routes.xml
+++ b/etc/frontend/routes.xml
@@ -2,7 +2,7 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="standard">
-        <route id="coignate" frontName="coingate">
+        <route id="coingate" frontName="coingate">
             <module name="CoinGate_Merchant" />
         </route>
     </router>


### PR DESCRIPTION
There is a typo in the route id (coignate instead of coingate).